### PR TITLE
fix: make morrenus daily limit go up by 1 after succesfull download

### DIFF
--- a/smd/lua/endpoints.py
+++ b/smd/lua/endpoints.py
@@ -85,7 +85,7 @@ def get_morrenus(dest: Path, app_id: str) -> Optional[Path]:
                 data = tf.read()
                 print(
                     Fore.GREEN
-                    + f"Morrenus Daily Limit: {usage}/{limit}"
+                    + f"Morrenus Daily Limit: {usage+1}/{limit}"
                     + Style.RESET_ALL
                 )
                 lua_bytes = read_lua_from_zip(io.BytesIO(data), decode=False)
@@ -111,3 +111,4 @@ def get_morrenus(dest: Path, app_id: str) -> Optional[Path]:
             with lua_path.open("wb") as f:
                 f.write(lua_bytes)
             return lua_path
+


### PR DESCRIPTION
I noticed a small bug the first time i actually used morrenus in SMD outside of testing so this patches it.

It was displaying the current daily limit usage from pre-download so i simply made it count up by 1 for the spent integer i tried matching the commit title to yours this time if i did it wrong feel free to just rename it lol